### PR TITLE
Makes sample rate optional

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -109,6 +109,11 @@ Client.prototype.send_data = function (buf) {
 };
 
 Client.prototype.send = function(data, sample_rate, tags) {
+	if (!tags && Array.isArray(sample_rate)) {
+		tags = sample_rate;
+		sample_rate = undefined;
+	}
+
     if (!sample_rate)
         sample_rate = 1;
 


### PR DESCRIPTION
This allows commands like 

```
c.histogram('node_test.some_service.data', 100, ["tag1","tag2"]);
```
