### PR TITLE
Add global tags

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -6,7 +6,7 @@ var mt = new mersenne.MersenneTwister19937();
 
 var EPHEMERAL_LIFETIME_MS = 1000;
 
-var Client = function(host, port, socket) {
+var Client = function(host, port, socket, options) {
     this.host = host || "localhost";
     this.port = port || 8125;
 
@@ -17,6 +17,9 @@ var Client = function(host, port, socket) {
     // socket is demand allocated.  This ephemeral socket is closed
     // after being idle for EPHEMERAL_LIFETIME_MS.
     this.ephemeral_socket = this.last_used_timer = null;
+
+    options = options || {};
+    this.global_tags = options.global_tags;
 };
 
 Client.prototype.timing = function(stat, time, sample_rate, tags) {
@@ -109,10 +112,10 @@ Client.prototype.send_data = function (buf) {
 };
 
 Client.prototype.send = function(data, sample_rate, tags) {
-	if (!tags && Array.isArray(sample_rate)) {
-		tags = sample_rate;
-		sample_rate = undefined;
-	}
+    if (!tags && Array.isArray(sample_rate)) {
+        tags = sample_rate;
+        sample_rate = undefined;
+    }
 
     if (!sample_rate)
         sample_rate = 1;
@@ -130,11 +133,21 @@ Client.prototype.send = function(data, sample_rate, tags) {
     else
         sampled_data = data;
 
-    if (tags && Array.isArray(tags)) {
-        var tagStr = tags.join(",");
+    if (this.global_tags || tags) {
+        var merged_tags = [];
 
-        for (stat in sampled_data)
-            sampled_data[stat] = sampled_data[stat] + "|#" + tagStr;
+        if (Array.isArray(this.global_tags))
+          merged_tags = merged_tags.concat(this.global_tags);
+
+
+        if (Array.isArray(tags))
+          merged_tags = merged_tags.concat(tags);
+
+        if (merged_tags.length > 0) {
+          var merged_tags_str = merged_tags.join(',');
+          for (stat in sampled_data)
+              sampled_data[stat] = sampled_data[stat] + "|#" + merged_tags_str;
+        }
     }
 
     for (var stat in sampled_data) {


### PR DESCRIPTION
This PR adds the ability to set global tags when creating the client. These tags will be added to all metrics delivered by the client.

Usage:

```
var c = new StatsD('example.org', 8125, null, {global_tags: ['environment:production']})
```
