### PR TITLE
version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-dogstatsd",
   "description": "node client for extended StatsD server of Datadog",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Young Han Lee",
   "repository": {
     "type": "git",


### PR DESCRIPTION
latest version in npm doesn't match master

this bumps version to `0.0.7`

please publish new version