### PR TITLE
Check environment variables for host and port

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -7,8 +7,8 @@ var mt = new mersenne.MersenneTwister19937();
 var EPHEMERAL_LIFETIME_MS = 1000;
 
 var Client = function(host, port, socket, options) {
-    this.host = host || process.env.DOGSTATSD_PORT_8125_UDP_ADDR || "localhost";
-    this.port = port || process.env.DOGSTATSD_PORT_8125_UDP_PORT || 8125;
+    this.host = host || process.env.DOGSTATSD_HOSTNAME || "localhost";
+    this.port = port || process.env.DOGSTATSD_PORT || 8125;
 
     // optional shared socket
     this.socket = socket;

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -7,8 +7,8 @@ var mt = new mersenne.MersenneTwister19937();
 var EPHEMERAL_LIFETIME_MS = 1000;
 
 var Client = function(host, port, socket, options) {
-    this.host = host || "localhost";
-    this.port = port || 8125;
+    this.host = host || process.env.DOGSTATSD_PORT_8125_UDP_ADDR || "localhost";
+    this.port = port || process.env.DOGSTATSD_PORT_8125_UDP_PORT || 8125;
 
     // optional shared socket
     this.socket = socket;


### PR DESCRIPTION
Uses the environment variables `DOGSTATSD_HOSTNAME` and `DOGSTATSD_PORT` for host and port if set. These variables were defined by DataDog in [this issue](https://github.com/DataDog/docker-dd-agent/issues/195).

